### PR TITLE
Change the display name

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-﻿=== Google and Facebook Remarketing & Marketing plugin for WooCommerce | ROI Hunter Easy ===
+﻿=== Automate Your Remarketing | ROI Hunter Easy Ads ===
 Contributors: roihuntereasy, vyskoczilova
 Tags: WooCommerce, Google Dynamic Remarketing, Facebook Dynamic Retargeting, Product Feed, Search Ads
 Requires at least: 4.6

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ If you would have any difficulty with the usage of this extension, or have any i
 
 == Changelog ==
 
+= 1.0.4 (2019-09-20) =
+* Changed the display name
+
 = 1.0.3 (2019-07-08) =
 * Changed internal iframe URL (for FE, GSTV-161)
 

--- a/roi-hunter-easy-for-woocommerce.php
+++ b/roi-hunter-easy-for-woocommerce.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: ROI Hunter Easy for WooCommerce
 Description: Turn visitors into customers.
-Version:     1.0.3
+Version:     1.0.4
 Author:      ROI Hunter Easy
 Author URI:  https://easy.roihunter.com
 */
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'RH_EASY_DIR', plugin_dir_path( __FILE__ ) );
 define( 'RH_EASY_URL', plugin_dir_url( __FILE__ ) );
 define( 'RH_EASY_BASENAME', plugin_basename( __FILE__ ) );
-define( 'RH_EASY_VERSION', '1.0.3' );
+define( 'RH_EASY_VERSION', '1.0.4' );
 define( 'RH_EASY_FRONTEND_URL', 'https://goostav-fe.roihunter.com/' );
 define( 'RH_EASY_MIN_WC_VERSION', '3.4.0');
 


### PR DESCRIPTION
_We have been required by Facebook (who owns Instagram, Facebook, WhatsApp, and many other trademarks) to close your plugin. They have told us directly that they longer permit the use of their wordmark in your display name, which includes the words Instagram, Facebook, FB, Insta, and Gram. So that means no, you cannot use "for Instagram" or even "with WhatsApp" anymore. This is because they have determined plugins are applications, and applications may not use their brand in the name._ More details in the email from wp.org. & Kateřina H.

Icon image as well changed and pushed to the repo.