### PR TITLE
Rename roi_hunter_easy_public_scripts function

### DIFF
--- a/includes/enqueue_scripts.php
+++ b/includes/enqueue_scripts.php
@@ -14,31 +14,31 @@ if ( ! defined( 'WPINC' ) ) {
  * @subpackage plugin_slug/includes
  */
 
-add_action( 'wp_enqueue_scripts', 'plugin_slug_public_scripts' );
-function plugin_slug_public_scripts( $hook ) {     
+add_action( 'wp_enqueue_scripts', 'roi_hunter_easy_public_scripts' );
+function roi_hunter_easy_public_scripts( $hook ) {
 
     $helper = new RH_Easy_Helper;
-    
+
     // Check for FB remarketing
     if ( $helper->get_option('fb_pixel_id') ) {
         $fb_active = true;
     } else {
         $fb_active = false;
     }
-    
+
     // Check for Google remarketing
     if ( $helper->get_option('google_conversion_id') && $helper->get_option('google_conversion_label') ) {
         $gtm_active = true;
     } else {
         $gtm_active = false;
     }
-    
+
     // At least one active - include a jQuery for AddToCart event
     if ( $fb_active || $gtm_active ) {
 
         $suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG  ? '' : '.min' );
         $version = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? time() : RH_EASY_VERSION );
-        
+
         wp_enqueue_script( 'roi-hunter-easy', RH_EASY_URL . 'assets/js/public'.$suffix.'.js', array('jquery'), $version, false );
         wp_localize_script( 'roi-hunter-easy', 'rhe', array(
             'ajax_url' => admin_url( 'admin-ajax.php' ),
@@ -48,5 +48,5 @@ function plugin_slug_public_scripts( $hook ) {
         ) );
 
     }
-    
+
 }


### PR DESCRIPTION
```## Generic function (and/or define) names

All plugins must have unique function names, namespaces, defines, and classnames. This prevents your plugin from conflicting with other plugins or themes. We need you to update your plugin to use more unique and distinct names.

A good way to do this is with a prefix. For example, if your plugin is called "Easy Custom Post Types" then you could use names like these:

function ecpt_save_post()
define( ‘ECPT_LICENSE’, true );
class ECPT_Admin{}
namespace EasyCustomPostTypes;

Don't try to use two letter slugs anymore. We have over 60 THOUSAND plugins on WordPress.org alone, you’re going to run into conflicts.

Similarly, don't use __ (double underscores), wp_ , or _ (single underscore) as a prefix. Those are reserved for WordPress itself. You can use them inside your classes, but not as stand-alone function.

Remember: Good names are unique and distinct. This will help you and the next person in debugging, as well as prevent conflicts.

Some examples from your plugin:

roi-hunter-easy-for-woocommerce/includes/enqueue_scripts.php:18:function plugin_slug_public_scripts( $hook ) {```