### PR TITLE
[GSTV-84] Allow clearing customer data using POST /state endpoint

### DIFF
--- a/includes/rest-api-endpoints.php
+++ b/includes/rest-api-endpoints.php
@@ -190,11 +190,9 @@ class RH_Easy_Custom_REST_API extends WP_REST_Controller {
 
             $data = array();
 
-            // get the value for our settings (skip not existing params)
+            // get the value for our settings
             foreach( $collected as $key => $value ) {
-                if ( $params[ $key ] ) {
-                    $data[ $key ] = $params[ $key ];
-                }
+                $data[ $key ] = $params[ $key ];
             }
 
             // save into plugin settings


### PR DESCRIPTION
Adding more flexibility to POST /state endpoint.
This is not 100% necessary now because Goostav is using dedicated endpoints https://github.com/roihunter/goostav/pull/2733 but with this change the behavior is same as for other plugins.

https://roihunter.atlassian.net/browse/GSTV-84